### PR TITLE
Add Check to Ensure crossSaveOverride data is valid before applying

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -81,7 +81,7 @@ export function QueryEditor({ query, onChange, onRunQuery, datasource }: Props) 
         let membershipId = v.membershipId;
         let membershipType = v.membershipType;
 
-        if (v.crossSaveOverride) {
+        if (v.crossSaveOverride && v.crossSaveOverride.membershipType > 0) {
           membershipId = v.crossSaveOverride.membershipId;
           membershipType = v.crossSaveOverride.membershipType;
         }


### PR DESCRIPTION
1. What does this PR do?
This PR fixes a bug in the QueryEditor where the plugin would attempt to perform a character search even if character data from the https://elastic.destinytrialsreport.com api. This resulted in failed api calls to the Grafana Plugin

2. Why is this change necessary?
If the member name search against the https://elastic.destinytrialsreport.com returned character data with invalid crossSave data - for example a character without any crossSave info, this resulted in invalid data being sent to the bungieAPI, which in turn returned errors

3. How was this tested?
Environment: Built inside a VSCode Linux Dev Container (Node 22 / Go 1.19).

Manual Test: Verified that the "Character Search" dropdown remains idle until a valid Bungie ID/Membership ID is provided. Once provided, characters are retrieved successfully for both the current user and test IDs. See Screenshots.

Regression: Confirmed that existing search functionality still works as expected once the ID is present.

4. Important Note on the Base Branch
I have based this branch on the v1.0.0 tag rather than the current main branch. During development, I encountered significant dependency conflicts on the latest main branch, and notice automated builds within git seemed to be failing, indicating a possible issue with some of the existing environment files.

By using the v1.0.0 baseline, I was able to verify the logic fix in a stable environment. This PR contains only the single-line change in src/components/QueryEditor.tsx.

Before:
<img width="1511" height="363" alt="Before" src="https://github.com/user-attachments/assets/ac8d777b-3d06-4892-a7cd-a6d4481d2fdd" />

After:
<img width="1441" height="420" alt="After" src="https://github.com/user-attachments/assets/9fa6bb7f-5016-416f-a9c4-38385d264835" />
